### PR TITLE
Revert to manual creation of Google Sheet

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -1,3 +1,5 @@
+// Reverted to manual sheet creation instead of auto-creation of gsheet
+
 function onOpen() {
   var ui = SpreadsheetApp.getUi();
   ui.createMenu('Amplitude Trigger')


### PR DESCRIPTION
Auto-creation of Google Sheet hasn't worked out as expected, reverting this change.

README was updated for better instructions & timestamp functionality has been added to the script using the date-time field available in the sample sheet.